### PR TITLE
Support for Angular inline CSS #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,12 @@
           "group": "navigation"
         },
         {
+          "when": "resourceLangId == typescript",
+          "command": "fabulous.showPanel",
+          "alt": "fabulous.showPanel",
+          "group": "navigation"
+        },
+        {
           "when": "resourceLangId == javascriptreact",
           "command": "fabulous.showPanel",
           "alt": "fabulous.showPanel",

--- a/src/extension/Manager.ts
+++ b/src/extension/Manager.ts
@@ -15,7 +15,9 @@ export default class Manager {
     this.panel = panel;
 
     vscode.window.onDidChangeActiveTextEditor(activeEditor => {
-      const languageId = activeEditor ? activeEditor.document.languageId : undefined;
+      const languageId = activeEditor
+        ? activeEditor.document.languageId
+        : undefined;
       if (
         languageId === "css" ||
         languageId === "scss" ||
@@ -24,7 +26,6 @@ export default class Manager {
         this.inspector = CSSFileInspector;
         this.activeEditor = activeEditor;
         this.languageId = languageId;
-
       } else if (
         languageId === "javascript" ||
         languageId === "javascriptreact" ||
@@ -33,7 +34,6 @@ export default class Manager {
         this.inspector = StyledComponentsInspector;
         this.activeEditor = activeEditor;
         this.languageId = languageId;
-
       } else if (languageId === "typescript") {
         this.inspector = DecoratedClassComponentsInspector;
         this.activeEditor = activeEditor;
@@ -90,7 +90,7 @@ export default class Manager {
   ) {
     let payload = null;
     if (this.inspector) {
-      const blocks = this.inspector.getEdiableBlocks(
+      const blocks = this.inspector.getEditableBlocks(
         activeFileContent,
         this.languageId
       );
@@ -195,7 +195,7 @@ export default class Manager {
           .then(() => {
             if (this.activeEditor && this.inspector) {
               const activeFileContent = this.activeEditor.document.getText();
-              const blocks = this.inspector.getEdiableBlocks(
+              const blocks = this.inspector.getEditableBlocks(
                 activeFileContent,
                 this.languageId
               );

--- a/src/extension/Manager.ts
+++ b/src/extension/Manager.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { FileHandler, EditableBlock } from "./file-handlers/types";
 import CSSFileInspector from "./file-handlers/css-file";
 import StyledComponentsInspector from "./file-handlers/js";
+import DecoratedClassComponentsInspector from "./file-handlers/ts";
 
 export default class Manager {
   private activeEditor: vscode.TextEditor | undefined;
@@ -14,24 +15,29 @@ export default class Manager {
     this.panel = panel;
 
     vscode.window.onDidChangeActiveTextEditor(activeEditor => {
+      const languageId = activeEditor ? activeEditor.document.languageId : undefined;
       if (
-        activeEditor &&
-        (activeEditor.document.languageId === "css" ||
-          activeEditor.document.languageId === "scss" ||
-          activeEditor.document.languageId === "postcss")
+        languageId === "css" ||
+        languageId === "scss" ||
+        languageId === "postcss"
       ) {
         this.inspector = CSSFileInspector;
         this.activeEditor = activeEditor;
-        this.languageId = activeEditor.document.languageId;
+        this.languageId = languageId;
+
       } else if (
-        activeEditor &&
-        (activeEditor.document.languageId === "javascript" ||
-          activeEditor.document.languageId === "javascriptreact" ||
-          activeEditor.document.languageId === "typescriptreact")
+        languageId === "javascript" ||
+        languageId === "javascriptreact" ||
+        languageId === "typescriptreact"
       ) {
         this.inspector = StyledComponentsInspector;
         this.activeEditor = activeEditor;
-        this.languageId = activeEditor.document.languageId;
+        this.languageId = languageId;
+
+      } else if (languageId === "typescript") {
+        this.inspector = DecoratedClassComponentsInspector;
+        this.activeEditor = activeEditor;
+        this.languageId = languageId;
       }
     });
 
@@ -54,12 +60,13 @@ export default class Manager {
 
   isAcceptableLaguage(languageId: string) {
     return (
-      languageId === "javascript" ||
       languageId === "css" ||
-      languageId === "javascriptreact" ||
-      languageId === "typescriptreact" ||
       languageId === "scss" ||
-      languageId === "postcss"
+      languageId === "postcss" ||
+      languageId === "javascript" ||
+      languageId === "typescript" ||
+      languageId === "javascriptreact" ||
+      languageId === "typescriptreact"
     );
   }
 

--- a/src/extension/file-handlers/css-file.ts
+++ b/src/extension/file-handlers/css-file.ts
@@ -37,7 +37,7 @@ function getCSSRules(cssString: string, languageId: string) {
 }
 
 const CSSFileInspector: FileHandler = {
-  getEdiableBlocks(fileContent: string, languageId: string) {
+  getEditableBlocks(fileContent: string, languageId: string) {
     return getCSSRules(fileContent, languageId);
   },
   updateProperty(activeBlock: EditableBlock, prop: string, value: string) {

--- a/src/extension/file-handlers/js.ts
+++ b/src/extension/file-handlers/js.ts
@@ -6,21 +6,14 @@ import {
   getRules,
   removeProperty
 } from "./utils";
-import { FileHandler, EditableBlock } from "./types";
-import { NodeSource } from "postcss";
-
-interface StyleExpresions {
-  name: string;
-  cssString: string;
-  location: NodeSource;
-}
+import { FileHandler, EditableBlock, StyleExpressions } from "./types";
 
 function wrapWithDummySelector(declaraions: string) {
   return `.dummy{${declaraions}}`;
 }
 
 export function getTaggedTemplateExpressionStrings(ast: any) {
-  const results: StyleExpresions[] = [];
+  const results: StyleExpressions[] = [];
   traverse(ast, {
     TaggedTemplateExpression(path: any) {
       const cssString = path.node.quasi.quasis[0].value.raw;

--- a/src/extension/file-handlers/js.ts
+++ b/src/extension/file-handlers/js.ts
@@ -81,7 +81,7 @@ export function getEditableBlocks(content: string, languageId: string) {
 }
 
 const StyledComponentsInspector: FileHandler = {
-  getEdiableBlocks(fileContent: string, languageId: string) {
+  getEditableBlocks(fileContent: string, languageId: string) {
     return getEditableBlocks(fileContent, languageId);
   },
   updateProperty(activeBlock: EditableBlock, prop: string, value: string) {

--- a/src/extension/file-handlers/ts.ts
+++ b/src/extension/file-handlers/ts.ts
@@ -1,0 +1,133 @@
+import traverse from "@babel/traverse";
+import { parse } from "../parsers/babel";
+import {
+  updateProperty,
+  getDeclarations,
+  getRules,
+  removeProperty
+} from "./utils";
+import { FileHandler, EditableBlock, StyleExpressions } from "./types";
+import console = require("console");
+
+
+export function getClassDeclarationStrings(ast: any) {
+  const results: StyleExpressions[] = [];
+  traverse(ast, {
+    ClassDeclaration(path: any) {
+      try {
+        const stylesNode = path.node.decorators[0].expression.arguments[0].properties.find(
+          (prop: any) => prop.key.name === "styles"
+        );
+        if (stylesNode && stylesNode.value.elements.length > 0) {
+          const cssString = stylesNode.value.elements[0].quasis[0].value.raw;
+          const location = stylesNode.value.elements[0].quasis[0].loc;
+
+          results.push({
+            name: path.node.id.name,
+            cssString: cssString,
+            location: {
+              start: {
+                column: (location.start && location.start.column) || 0,
+                line: (location.start && location.start.line - 1) || 0
+              },
+              end: {
+                column: (location.end && location.end.column) || 0,
+                line: (location.end && location.end.line - 1) || 0
+              },
+              input: null as any
+            }
+          });
+        }
+      } catch (ex) {
+        // ignore?
+        console.log("Error", ex);
+      }
+    }
+  });
+  return results;
+}
+
+export function updateCSSProperty(
+  content: string,
+  name: string,
+  property: string,
+  value: string,
+  languageId: string
+) {
+  const ast = parse(content, languageId);
+  let updatedCssString = "";
+
+  traverse(ast, {
+    ClassDeclaration(path: any) {
+      try {
+        if (path.node.id.name) {
+          const stylesNode = path.node.decorators[0].expression.arguments[0].properties.find(
+            (prop: any) => prop.key.name === "styles"
+          );
+          if (stylesNode && stylesNode.value.elements.length > 0) {
+            const cssString = stylesNode.value.elements[0].quasis[0].value.raw;
+            updatedCssString = updateProperty(cssString, property, value);
+            stylesNode.value.elements[0].quasis[0].value.raw = updatedCssString;
+          }
+        }
+      } catch (ex) {
+        // ignore?
+        console.log("Error", ex);
+      }
+    }
+  });
+}
+
+export function getEditableBlocks(content: string, languageId: string) {
+  const ast = parse(content, languageId);
+  const styledBlocks = getClassDeclarationStrings(ast);
+
+  const results: EditableBlock[] = [];
+
+  styledBlocks.forEach(({ cssString, location }) => {
+    getRules(cssString).forEach(rule => {
+      const declarations = getDeclarations(rule);
+
+      // Get accurate overall locations based on total document and rule within styles string
+      const locStart = location.start ? location.start : {column: 0, line: 0};
+      const sourceStart = rule.source && rule.source.start || {column: 0, line: 0};
+      const sourceEnd = rule.source && rule.source.end || {column: 0, line: 0};
+
+      const startLine = locStart.line + sourceStart.line - 1;
+      const endLine = startLine + sourceEnd.line - sourceStart.line;
+      // If ` is on the same line as the CSS tag, then the start column should be the actual column
+      let startColumn = sourceStart.line === 1 ? locStart.column : sourceStart.column - 1;
+
+      results.push({
+        selector: rule.selector,
+        declarations,
+        source: {
+          start: {
+            column: startColumn,
+            line: startLine
+          },
+          end: {
+            column: sourceEnd.column,
+            line: endLine
+          },
+          input: (rule.source as any).input,
+        },
+        rule
+      });
+    });
+  });
+  return results;
+}
+
+const DecoratedClassComponentsInspector: FileHandler = {
+  getEdiableBlocks(fileContent: string, languageId: string) {
+    return getEditableBlocks(fileContent, languageId);
+  },
+  updateProperty(activeBlock: EditableBlock, prop: string, value: string) {
+    return updateProperty(activeBlock.rule, prop, value);
+  },
+  removeProperty(activeBlock: EditableBlock, prop: string) {
+    return removeProperty(activeBlock.rule, prop);
+  }
+};
+export default DecoratedClassComponentsInspector;

--- a/src/extension/file-handlers/ts.ts
+++ b/src/extension/file-handlers/ts.ts
@@ -9,7 +9,6 @@ import {
 import { FileHandler, EditableBlock, StyleExpressions } from "./types";
 import console = require("console");
 
-
 export function getClassDeclarationStrings(ast: any) {
   const results: StyleExpressions[] = [];
   traverse(ast, {
@@ -89,14 +88,21 @@ export function getEditableBlocks(content: string, languageId: string) {
       const declarations = getDeclarations(rule);
 
       // Get accurate overall locations based on total document and rule within styles string
-      const locStart = location.start ? location.start : {column: 0, line: 0};
-      const sourceStart = rule.source && rule.source.start || {column: 0, line: 0};
-      const sourceEnd = rule.source && rule.source.end || {column: 0, line: 0};
+      const locStart = location.start ? location.start : { column: 0, line: 0 };
+      const sourceStart = (rule.source && rule.source.start) || {
+        column: 0,
+        line: 0
+      };
+      const sourceEnd = (rule.source && rule.source.end) || {
+        column: 0,
+        line: 0
+      };
 
       const startLine = locStart.line + sourceStart.line - 1;
       const endLine = startLine + sourceEnd.line - sourceStart.line;
       // If ` is on the same line as the CSS tag, then the start column should be the actual column
-      let startColumn = sourceStart.line === 1 ? locStart.column : sourceStart.column - 1;
+      let startColumn =
+        sourceStart.line === 1 ? locStart.column : sourceStart.column - 1;
 
       results.push({
         selector: rule.selector,
@@ -110,7 +116,7 @@ export function getEditableBlocks(content: string, languageId: string) {
             column: sourceEnd.column,
             line: endLine
           },
-          input: (rule.source as any).input,
+          input: (rule.source as any).input
         },
         rule
       });
@@ -120,7 +126,7 @@ export function getEditableBlocks(content: string, languageId: string) {
 }
 
 const DecoratedClassComponentsInspector: FileHandler = {
-  getEdiableBlocks(fileContent: string, languageId: string) {
+  getEditableBlocks(fileContent: string, languageId: string) {
     return getEditableBlocks(fileContent, languageId);
   },
   updateProperty(activeBlock: EditableBlock, prop: string, value: string) {

--- a/src/extension/file-handlers/types.ts
+++ b/src/extension/file-handlers/types.ts
@@ -9,7 +9,7 @@ import { Declaration, NodeSource, Rule } from "postcss";
  * - CSS File handler - Deals with .css files to support CSS editing
  */
 export interface FileHandler {
-  getEdiableBlocks(fileContent: string, languageId: string): EditableBlock[];
+  getEditableBlocks(fileContent: string, languageId: string): EditableBlock[];
   updateProperty(
     activeBlock: EditableBlock,
     prop: string,
@@ -44,4 +44,3 @@ export interface StyleExpressions {
   cssString: string;
   location: NodeSource;
 }
-

--- a/src/extension/file-handlers/types.ts
+++ b/src/extension/file-handlers/types.ts
@@ -38,3 +38,10 @@ export interface EditableBlock {
   source?: NodeSource;
   rule: Rule;
 }
+
+export interface StyleExpressions {
+  name: string;
+  cssString: string;
+  location: NodeSource;
+}
+

--- a/src/extension/parsers/babel.ts
+++ b/src/extension/parsers/babel.ts
@@ -1,11 +1,18 @@
 import * as parser from "@babel/parser";
 
 export function parse(code: string, languageId: string) {
-  const isTS = languageId === "typescriptreact";
-  const additionalPlugin = isTS ? "typescript" : "flow";
+  const isTS = languageId.includes("typescript");
+  const plugins: parser.ParserPlugin[] = ["jsx", "classProperties"];
+
+  if (isTS) {
+    plugins.push("typescript");
+    plugins.push(["decorators", { decoratorsBeforeExport: true }]);
+  } else {
+    plugins.push("flow");
+  }
 
   return parser.parse(code, {
     sourceType: "module",
-    plugins: ["jsx", "classProperties", additionalPlugin]
+    plugins
   });
 }


### PR DESCRIPTION
@Raathigesh - please take a look at my PR and let me know if you have any questions or if you would like me to change re-architect any of my code.

This code has been lightly tested for some common scenarios, but should probably be tested more prior to merging.

Added support for Angular components by adding the following:
- typescript support
- decorator babel plugin
- `ClassDeclaration` listener for babel traverse
- Added manager to specifically handle typescript files

Updated types
other minor changes to a couple of bits of logic to make the code less verbose

resolves #13

### Screenshots

![image](https://user-images.githubusercontent.com/5461649/58682033-37d4bf80-832c-11e9-955e-875bbbb51db2.png)

![image](https://user-images.githubusercontent.com/5461649/58682000-1d9ae180-832c-11e9-8b60-f3c6e481b0b3.png)


### This is the file that I used for testing development

```typescript
import { Component } from '@angular/core';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html',
  styles: [
    `
      .h1 {
        font-size: 1.5em;
        text-align: center;
        color: palevioletred;
      }

      .section {
        padding: 4em;
        background: papayawhip;
      }
    `
  ]
})
export class AppComponent {
  title = 'fabulous-test';
}
```