### PR TITLE
Added support for HTML/Vue/Svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ Fabulous supports the followings
 - 💅 CSS-in-JS libs which supports template literal ([styled-components](https://github.com/styled-components/styled-components), [emotion](https://github.com/emotion-js/emotion), [linaria](https://github.com/callstack/linaria))
 - 🎨 CSS rules from `.css` files
 - 🌈 CSS rules from `.scss` files
+- 🌏 CSS rules from `.html` files - these must be in a `<style>` tag and the style tag must be within the `<head>` tag
+- 🌛 CSS rules from `component.ts` Angular component files that have inline styles within the ` @Component({ styles:[``] }) ` decorator
+- 🌟 CSS rules from `.vue` files that have a `<style>` tag in the root of the file
+- 💍 CSS rules from `.svelte` files that have a `<style>` tag in the root of the file
 
 > Fabulous is still in Preview. Give it a try and [let us know](https://github.com/Raathigesh/fabulous/issues) when things don't go well.
 
 ## Getting started
 
 - Install the [Fabulous](https://marketplace.visualstudio.com/items?itemName=Raathigeshan.fabulous) extension in VS Code
-- After opening a `css`, `scss`, `js`, `jsx` or `tsx` file, click on the <img src="https://affectionate-booth-10a1f4.netlify.com/tiny-icon.png" width="20px" /> icon to toggle the side-bar
+- After opening a `css`, `scss`, `js`, `jsx`, `tsx`, `component.ts`, `vue` or `svelte` file, click on the <img src="https://affectionate-booth-10a1f4.netlify.com/tiny-icon.png" width="20px" /> icon to toggle the side-bar
 - Place your cursor in a CSS rule or in a Styled component template literal
 - You should see the sidebar controls become active
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
     "menus": {
       "editor/title": [
         {
+          "when": "resourceLangId == html",
+          "command": "fabulous.showPanel",
+          "alt": "fabulous.showPanel",
+          "group": "navigation"
+        },
+        {
           "when": "resourceLangId == css",
           "command": "fabulous.showPanel",
           "alt": "fabulous.showPanel",
@@ -56,7 +62,7 @@
           "group": "navigation"
         },
         {
-          "when": "resourceLangId == typescript",
+          "when": "resourceLangId == typescript && isAngularComponent",
           "command": "fabulous.showPanel",
           "alt": "fabulous.showPanel",
           "group": "navigation"
@@ -75,6 +81,18 @@
         },
         {
           "when": "resourceLangId == postcss",
+          "command": "fabulous.showPanel",
+          "alt": "fabulous.showPanel",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == svelte",
+          "command": "fabulous.showPanel",
+          "alt": "fabulous.showPanel",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceLangId == vue",
           "command": "fabulous.showPanel",
           "alt": "fabulous.showPanel",
           "group": "navigation"
@@ -104,6 +122,7 @@
     "@types/babel-traverse": "^6.25.5",
     "@types/mocha": "^2.2.42",
     "@types/node": "^10.12.21",
+    "@types/parse5": "^5.0.0",
     "@types/react": "^16.8.14",
     "@types/react-dom": "^16.8.4",
     "@types/react-select": "^2.0.17",
@@ -135,6 +154,7 @@
   },
   "dependencies": {
     "@babel/traverse": "^7.4.3",
+    "parse5": "^5.1.0",
     "postcss": "^7.0.14",
     "postcss-scss": "^2.0.0",
     "rebass": "^3.1.0"

--- a/src/extension/Manager.ts
+++ b/src/extension/Manager.ts
@@ -3,6 +3,8 @@ import { FileHandler, EditableBlock } from "./file-handlers/types";
 import CSSFileInspector from "./file-handlers/css-file";
 import StyledComponentsInspector from "./file-handlers/js";
 import DecoratedClassComponentsInspector from "./file-handlers/ts";
+import HtmlInspector from "./file-handlers/html";
+import { isAngularComponentRegex } from "./file-handlers/utils";
 
 export default class Manager {
   private activeEditor: vscode.TextEditor | undefined;
@@ -18,7 +20,16 @@ export default class Manager {
       const languageId = activeEditor
         ? activeEditor.document.languageId
         : undefined;
+
       if (
+        languageId === "html" ||
+        languageId === "svelte" ||
+        languageId === "vue"
+      ) {
+        this.inspector = HtmlInspector;
+        this.activeEditor = activeEditor;
+        this.languageId = languageId;
+      } else if (
         languageId === "css" ||
         languageId === "scss" ||
         languageId === "postcss"
@@ -60,13 +71,16 @@ export default class Manager {
 
   isAcceptableLaguage(languageId: string) {
     return (
+      languageId === "html" ||
       languageId === "css" ||
       languageId === "scss" ||
       languageId === "postcss" ||
       languageId === "javascript" ||
       languageId === "typescript" ||
       languageId === "javascriptreact" ||
-      languageId === "typescriptreact"
+      languageId === "typescriptreact" ||
+      languageId === "svelte" ||
+      languageId === "vue"
     );
   }
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -2,10 +2,36 @@ import * as vscode from "vscode";
 import ContentProvider from "./ContentProvider";
 import { join } from "path";
 import Manager from "./Manager";
+import { isAngularComponentRegex } from "./file-handlers/utils";
 
 export function activate(context: vscode.ExtensionContext) {
   const contentProvider = new ContentProvider();
   let currentPanel: vscode.WebviewPanel | undefined = undefined;
+
+  /**
+   * Set a custom context variable of "isAngularComponent" so that in package.json  menus.editor/title "when" clause can distinguish
+   * Angular components from other typescript files so that the plugin can remain dormant for regular typescript files
+   */
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(activeEditor => {
+      if (activeEditor) {
+        let isAngularComponent = false;
+        try {
+          isAngularComponent = isAngularComponentRegex.test(
+            activeEditor.document.uri.path
+          );
+        } catch (ex) {
+          console.log("Error checking isAngularComponent", ex);
+        } finally {
+          vscode.commands.executeCommand(
+            "setContext",
+            "isAngularComponent",
+            isAngularComponent
+          );
+        }
+      }
+    })
+  );
 
   let disposable = vscode.commands.registerCommand("fabulous.showPanel", () => {
     if (currentPanel) {

--- a/src/extension/file-handlers/html.ts
+++ b/src/extension/file-handlers/html.ts
@@ -1,0 +1,110 @@
+import * as parse5 from "parse5";
+import { EditableBlock, FileHandler, StyleExpressions } from "./types";
+import {
+  getDeclarations,
+  getNodeSourceWithLocationOffset,
+  getRules,
+  removeProperty,
+  updateProperty
+} from "./utils";
+import console = require("console");
+
+/**
+ * Parse a document for style tags
+ *
+ * The only two locations that tags are parsed:
+ * - At the root of the document, such as Vue SFC
+ * - A style tag within the <head> of a document
+ * Any other location will be ignored to ensure that the entire tree does not need to be walked
+ * @param document
+ */
+export function getStyleTags(
+  document: parse5.DocumentFragment
+): StyleExpressions[] {
+  let results: StyleExpressions[] = [];
+  try {
+    // Get any root level style tags
+    let styleNodes: parse5.DefaultTreeTextNode[] = (document as any).childNodes
+      .filter((node: parse5.DefaultTreeNode) => node.nodeName === "style")
+      .map((styleNode: any) => styleNode.childNodes[0]);
+
+    try {
+      // Get any <style> tags that are within a <head> tag
+      if (
+        (document as any).childNodes[0].nodeName === "html" &&
+        (document as any).childNodes[0].childNodes[0].nodeName === "head"
+      ) {
+        styleNodes = styleNodes.concat(
+          (document as any).childNodes[0].childNodes[0].childNodes
+            .filter((node: parse5.DefaultTreeNode) => node.nodeName === "style")
+            .map((styleNode: any) => styleNode.childNodes[0])
+        );
+      }
+    } catch (ex) {
+      // TODO: handle errors in some way (maybe just log to output so the user knows we had an error)
+      console.log("Error parsing file", ex);
+    }
+
+    // Convert format to StyleExpression
+    results = styleNodes.map(node => {
+      const loc = node.sourceCodeLocation as parse5.Location;
+      return {
+        name: node.nodeName,
+        cssString: node.value,
+        location: {
+          input: null as any,
+          start: {
+            column: loc.startCol,
+            line: loc.startLine - 1
+          },
+          end: {
+            column: loc.endCol,
+            line: loc.endLine - 1
+          }
+        }
+      } as StyleExpressions;
+    });
+  } catch (ex) {
+    // TODO: handle errors in some way (maybe just log to output so the user knows we had an error)
+    console.log("Error parsing file", ex);
+  }
+  return results;
+}
+
+export function getEditableBlocks(content: string) {
+  // Parse HTML document as a fragment to ensure extra tags are not added by parse5
+  const document: parse5.DocumentFragment = parse5.parseFragment(content, {
+    sourceCodeLocationInfo: true
+  }) as parse5.DefaultTreeDocument;
+  // Search document for style tags
+  const styledBlocks = getStyleTags(document);
+
+  const results: EditableBlock[] = [];
+
+  // parse the CSS from each style tag and add to EditableBlock[]
+  styledBlocks.forEach(({ cssString, location }) => {
+    getRules(cssString).forEach(rule => {
+      const declarations = getDeclarations(rule);
+      results.push({
+        selector: rule.selector,
+        declarations,
+        source: getNodeSourceWithLocationOffset(location, rule),
+        rule
+      });
+    });
+  });
+  return results;
+}
+
+const HtmlInspector: FileHandler = {
+  getEditableBlocks(fileContent: string, languageId?: string) {
+    return getEditableBlocks(fileContent);
+  },
+  updateProperty(activeBlock: EditableBlock, prop: string, value: string) {
+    return updateProperty(activeBlock.rule, prop, value);
+  },
+  removeProperty(activeBlock: EditableBlock, prop: string) {
+    return removeProperty(activeBlock.rule, prop);
+  }
+};
+export default HtmlInspector;

--- a/src/extension/file-handlers/js.ts
+++ b/src/extension/file-handlers/js.ts
@@ -39,6 +39,7 @@ export function getTaggedTemplateExpressionStrings(ast: any) {
   return results;
 }
 
+// FIXME: IS THIS USED? NO REFERENCE IN CODEBASE, WE SHOULD REMOVE THIS
 export function updateCSSProperty(
   content: string,
   name: string,

--- a/src/extension/file-handlers/types.ts
+++ b/src/extension/file-handlers/types.ts
@@ -44,3 +44,8 @@ export interface StyleExpressions {
   cssString: string;
   location: NodeSource;
 }
+
+export interface LocationPosition {
+  column: 0;
+  line: 0;
+}

--- a/src/extension/file-handlers/utils.ts
+++ b/src/extension/file-handlers/utils.ts
@@ -1,6 +1,8 @@
 import * as postcss from "postcss";
-import { Rule, Declaration } from "postcss";
+import { Rule, Declaration, NodeSource } from "postcss";
 import { processWithPlugin } from "../parsers/post-css";
+
+export const isAngularComponentRegex = /.component.ts$/;
 
 export const getRules = (cssString: string, syntax?: postcss.Syntax) => {
   const results: Rule[] = [];
@@ -59,4 +61,45 @@ export const removeProperty = (rule: postcss.Rule, propertyName: string) => {
     });
   }
   return rule.toString();
+};
+
+/**
+ * When CSS is parsed from a parent document, the locations must take
+ * into account the overall location and the location of a specific tag.
+ * This utility will return a NodeSource that will ensure that the overall
+ * document is correctly calculated.
+ * @param location
+ * @param rule
+ */
+export const getNodeSourceWithLocationOffset = (
+  location: NodeSource,
+  rule: Rule
+): NodeSource => {
+  // Get accurate overall locations based on total document and rule within styles string
+  const locStart = location.start ? location.start : { column: 0, line: 0 };
+  const sourceStart = (rule.source && rule.source.start) || {
+    column: 0,
+    line: 0
+  };
+  const sourceEnd = (rule.source && rule.source.end) || {
+    column: 0,
+    line: 0
+  };
+
+  const startLine = locStart.line + sourceStart.line - 1;
+  const endLine = startLine + sourceEnd.line - sourceStart.line;
+  // If ` is on the same line as the CSS tag, then the start column should be the actual column
+  let startColumn =
+    sourceStart.line === 1 ? locStart.column : sourceStart.column - 1;
+  return {
+    start: {
+      column: startColumn,
+      line: startLine
+    },
+    end: {
+      column: sourceEnd.column,
+      line: endLine
+    },
+    input: (rule.source as any).input
+  };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,6 +878,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.5.tgz#27733a949f5d9972d87109297cffb62207ace70f"
   integrity sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g==
 
+"@types/parse5@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.0.tgz#9ae2106efc443d7c1e26570aa8247828c9c80f11"
+  integrity sha512-J5D3z703XTDIGQFYXsnU9uRCW9e9mMEFO0Kpe6kykyiboqziru/RlZ0hM2P+PKTG4NHG1SjLrqae/NrV2iJApQ==
+
 "@types/prop-types@*":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
@@ -4833,6 +4838,11 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
+
+parse5@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
+  integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
 parseurl@~1.3.2:
   version "1.3.3"


### PR DESCRIPTION
@Raathigesh - please take a look at my changes and let me know if you have any questions.

- Added support for HTML files if the `style` tag is within a `head` tag
- Added support for vue and svelte files if the style tag is in the root directory
- refactored some of the typescript parser code to allow code reuse with the html parser code
- added check so that only angular components activate the plugin instead of all typescript files 🎉 
    - Now the plugin only activates for typescript files that end with `component.ts` (look in extension.ts and package.json for the code to make this happen)
- updated readme to include the HTML/Vue/Svelte changes, as well as the TS changes

**Note**:`parse5` was added as a dependency for parsing HTML and providing source location information since the other two parsers did not support HTML.

resolves #14
resolves #10
work towards #20

### Regular TS file
**Fabulous icon is not shown**
![image](https://user-images.githubusercontent.com/5461649/58743568-505add80-83f1-11e9-8ddd-e7ae3bd9758a.png)

### Angular
**Fabulous icon is shown**
![image](https://user-images.githubusercontent.com/5461649/58743569-5650be80-83f1-11e9-8565-1c44986cd114.png)

### HTML
![image](https://user-images.githubusercontent.com/5461649/58743574-80a27c00-83f1-11e9-848e-1efa18b6e6f4.png)

### Vue
![image](https://user-images.githubusercontent.com/5461649/58743580-a596ef00-83f1-11e9-9d2f-50966a4b87e8.png)

### Svelte
![image](https://user-images.githubusercontent.com/5461649/58743583-b3e50b00-83f1-11e9-8e79-28154366c7e2.png)
