### PR TITLE
Handle unassigned template literal

### DIFF
--- a/src/extension/file-handlers/js.ts
+++ b/src/extension/file-handlers/js.ts
@@ -15,7 +15,7 @@ export function getTaggedTemplateExpressionStrings(ast: any) {
       const location = path.node.quasi.loc;
 
       results.push({
-        name: path.parent.id.name,
+        name: (path.parent.id && path.parent.id.name) || '',
         cssString: wrapWithDummySelector(cssString),
         location: {
           start: {


### PR DESCRIPTION
This will make #29 work without breaking the extension but it doesn't solve #29 completely. Looks like we don't handle nested template literals very well but we could fix that separately as an enhancement.